### PR TITLE
Fixed Examples button on Homepage points to a redundant route error.

### DIFF
--- a/frontend/src/pages/Components/Body/_InfoCointainer.js
+++ b/frontend/src/pages/Components/Body/_InfoCointainer.js
@@ -25,7 +25,7 @@ function InfoContainer() {
         <div>
           <a
             className="button button--success button--outline button--lg"
-            href={useBaseUrl("docs/react")}
+            href={useBaseUrl("docs/examples/react")}
           >
             Examples
           </a>


### PR DESCRIPTION
changed the anchor URL  of Home page Examples button to point to https://finalspaceapi.com/docs/examples/react/